### PR TITLE
Changing the start position for monsters

### DIFF
--- a/map_generator.go
+++ b/map_generator.go
@@ -74,7 +74,6 @@ func generate(filename string, Rows, Columns, humans, monster int, seed int64) *
 	i = perm[humans/2+cnt]
 
 	c := m.cells[i]
-	log.Printf("%d %d", c.X, c.Y)
 	// Make sure that the random cell we picked isn't it's own symetrique
 	// otherwise we won't get any ennemies
 	for {

--- a/map_generator.go
+++ b/map_generator.go
@@ -68,16 +68,32 @@ func generate(filename string, Rows, Columns, humans, monster int, seed int64) *
 	}
 	sort.Ints(m.humans)
 	// Random starter cell
-	i = perm[humans/2 + 1]
+	var cnt int
+	cnt = 1
+
+	i = perm[humans/2+cnt]
+
 	c := m.cells[i]
+	log.Printf("%d %d", c.X, c.Y)
 	// Make sure that the random cell we picked isn't it's own symetrique
 	// otherwise we won't get any ennemies
 	for {
+		// loop over the human position to check if the positions is free
+		var free_cell bool
+		free_cell = true
+		for _, idx := range m.humans {
+			if i == idx {
+				free_cell = false
+			}
+		}
+		// check the symmetry
 		symX, symY := f(c.X, c.Y, m.Rows, m.Columns)
-		if symX != c.X || symY != c.Y {
+		if (symX != c.X || symY != c.Y) && free_cell {
 			break
 		} else {
-			i = rand.Intn(m.Columns * m.Rows)
+			// pick the next random permuted integer
+			cnt = cnt + 1
+			i = perm[humans/2+cnt]
 			c = m.cells[i]
 		}
 	}

--- a/map_generator.go
+++ b/map_generator.go
@@ -68,7 +68,7 @@ func generate(filename string, Rows, Columns, humans, monster int, seed int64) *
 	}
 	sort.Ints(m.humans)
 	// Random starter cell
-	i = rand.Intn(m.Columns * m.Rows)
+	i = perm[humans/2 + 1]
 	c := m.cells[i]
 	// Make sure that the random cell we picked isn't it's own symetrique
 	// otherwise we won't get any ennemies


### PR DESCRIPTION
Currently the start positions for monsters can collide with a position already taken by a human group.
This results in troubles to find our species.
See seed 1520779839601939900 with the previous version. It should be checked since I am a newbie in Go ;)

In this fix, I pick an integer (see the code for the exact math) and loop over the human position to make sure it is free.